### PR TITLE
fix merge missing ones not carry over existing tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [3.1, 3.2, 3.3, 3.4]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build and Install Gem
+        run: |
+          gem build JunitTimingSplitter.gemspec && gem install junit_timing_splitter-1.1.0.gem
+      - name: Run Tests
+        run: ruby test/test_junit_timing_splitter.rb --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+## [Unreleased]
+
+## v1.1.0
+Improvements
+- Added GitHub Actions CI configuration to run on push to any branch and on merge to main.
+
+Bug Fixes
+- Fixed an issue where merging missing test files would overwrite previously assigned test cases in buckets.
+- Updated CLI and Splitter to accept an existing schema, ensuring that previous test assignments remain intact while merging missing tests.
+
+## v1.0.0
+- Initial release of JunitTimingSplitter with test parsing, splitting, schema generation, and basic merge functionality.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    junit_timing_splitter (1.0.0)
+    junit_timing_splitter (1.1.0)
       json (~> 2.1, >= 2.1.0)
       nokogiri (>= 1.15, < 2.0)
       thor (~> 1.0)

--- a/JunitTimingSplitter.gemspec
+++ b/JunitTimingSplitter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'junit_timing_splitter'
-  spec.version       = '1.0.0'
+  spec.version       = '1.1.0'
   spec.summary       = 'Split test files into evenly distributed buckets based on execution time'
   spec.description   = 'A tool to optimize parallel test execution by analyzing JUnit XML results and distributing test files across buckets.'
   spec.author        = 'Kim Yu Ng'
@@ -8,6 +8,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
   spec.homepage      = 'https://github.com/kimyu92/junit_timing_splitter'
   spec.license       = 'MIT'
+
+  spec.metadata['bug_tracker_uri'] = 'https://github.com/kimyu92/junit_timing_splitter/issues'
+  spec.metadata['documentation_uri'] = 'https://github.com/kimyu92/junit_timing_splitter/blob/main/README.md'
+  spec.metadata['changelog_uri'] = 'https://github.com/kimyu92/junit_timing_splitter/blob/main/CHANGELOG.md'
 
   spec.files = Dir["lib/**/*.rb"]
   spec.bindir = "bin"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JunitTimingSplitter
 
+[![GemVersion](https://img.shields.io/gem/v/junit_timing_splitter.svg?style=flat)](https://rubygems.org/gems/junit_timing_splitter)
+![CI](https://github.com/kimyu92/junit_timing_splitter/workflows/CI/badge.svg)
+
 `JunitTimingSplitter` is a tool written in Ruby designed to parse JUnit XML result files and distribute tests into evenly balanced buckets based on their total execution time. This tool is especially beneficial for optimizing parallel test execution in CI pipelines, drawing inspiration from CircleCI's `--split-by=timings` feature.
 
 ---
@@ -81,14 +84,14 @@ Missing test files:
 
 4. Merge the missing test cases from the existing schema
 ```sh
-bundle exec junit_timing_splitter merge --schema="output/buckets.json" --files="./spec/**/*.rb"
+bundle exec junit_timing_splitter merge --schema="output/buckets.json" --files="./spec/**/*_spec.rb"
 ```
 
 ## Development
 
 ```sh
 # rebuild
-rm junit_timing_splitter-1.0.0.gem && gem build JunitTimingSplitter.gemspec && gem install junit_timing_splitter-1.0.0.gem
+rm junit_timing_splitter-1.1.0.gem && gem build JunitTimingSplitter.gemspec && gem install junit_timing_splitter-1.1.0.gem
 ```
 
 ```sh

--- a/lib/junit_timing_splitter/cli.rb
+++ b/lib/junit_timing_splitter/cli.rb
@@ -65,7 +65,7 @@ module JunitTimingSplitter
         if missing_files.empty?
           puts 'No missing test files to merge.'
         else
-          splitter = JunitTimingSplitter::Splitter.new([], schema.buckets.size)
+          splitter = JunitTimingSplitter::Splitter.new([], schema.buckets.size, existing_schema: schema.buckets)
           buckets = splitter.merge_missing_files(missing_files)
           buckets_as_hashes = buckets.map(&:to_h)
           File.write(options[:schema], JSON.pretty_generate(buckets_as_hashes))

--- a/lib/junit_timing_splitter/splitter.rb
+++ b/lib/junit_timing_splitter/splitter.rb
@@ -2,10 +2,19 @@ module JunitTimingSplitter
   class Splitter
     attr_reader :parsed_timings, :total_splits, :buckets
 
-    def initialize(parsed_timings, total_splits)
+    def initialize(parsed_timings, total_splits, existing_schema: nil)
       @parsed_timings = parsed_timings
       @total_splits = total_splits
-      @buckets = Array.new(total_splits) { Bucket.new }
+      if existing_schema
+        @buckets = existing_schema.map do |bucket_hash|
+          b = Bucket.new
+          b.files = bucket_hash['files']
+          b.total_time = bucket_hash['total_time']
+          b
+        end
+      else
+        @buckets = Array.new(total_splits) { Bucket.new }
+      end
     end
 
     # Split the parsed timings into buckets based on total_splits


### PR DESCRIPTION
## Description
- fix merge missing test files not carry over existing tests in `buckets.json` when calling `bundle exec junit_timing_splitter merge --schema="output/buckets.json" --files="./spec/**/*_spec.rb"`, resulting in missing test files
- Add CI to run against ruby 3.1, 3.2, 3.3 and 3.4
- Add `CHANGELOG.md`